### PR TITLE
Add digest auth feature and general code cleanup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # godash
-An small amazon dash golang program to send web requests on button press.
+A small Amazon Dash Golang program to send web requests on button press.
 
 
 The program itself works well, but the Dockerfile and build for Raspberry Pi is a work in progress.
@@ -17,6 +17,9 @@ go build
 
 You can then do `mv conf-example.json conf.json` and edit that file to add the appropriate details.
 
+Adding a `username` parameter to your button will invoke curl w/ digest auth. This works well
+for digest-authenticated API end points. Like [Indigo](https://www.indigodomo.com).
+
 # Finding your dash button hardware address
 
 I haven't provided a program to do this, but this will help (an example on Mac, it's probably eth0 on Linux):
@@ -26,4 +29,4 @@ tcpdump -i en0 -e | grep who-has
 This will show some arp traffic for anything requesting an IP mac translation from the switch/router.  
 You should be able to figure out what address is attached to the button fairly easily. (Mine starts with ac:)
 
-I've only tested on Go 1.7.1.
+I've only tested on Go 1.7.1 and Go 1.8.

--- a/godash/conf-example.json
+++ b/godash/conf-example.json
@@ -1,10 +1,22 @@
 {
-    "nic": "en0",
-    "buttons": [
-        { 
-            "name": "Biona button",
-            "mac":"ac:xx:xx:xx:xx:xx",
-            "url":"https://maker.ifttt.com/trigger/biona_pressed/with/key/xxxxxxxxxxxxxxx"
-        }
-    ]
+  "nic": "en0",
+  "buttons": [
+    {
+        "name": "Biona button",
+        "mac":"ac:xx:xx:xx:xx:xx",
+        "url":"https://maker.ifttt.com/trigger/biona_pressed/with/key/xxxxxxxxxxxxxxx"
+    },
+    {
+        "name": "Mountain Dew",
+        "mac":"b4:7c:9c:5b:7d:28",
+        "url":"http://10.1.10.3:8176/actions/Mountain%20Dew&_method=execute",
+        "username":"indigo:password"
+    },
+    {
+        "name": "Pepsi",
+        "mac":"b4:7c:9c:5b:7d:29",
+        "url":"http://10.1.10.3:8176/actions/Pepsi&_method=execute",
+        "username":"indigo:password"
+    }
+  ]
 }

--- a/godash/main.go
+++ b/godash/main.go
@@ -1,103 +1,128 @@
 package main
 
+// Made it use digest auth so I can trigger actions in Indigo. -dnewhall
+
 import (
-    "encoding/json"
-    "net/http"
-	"bytes"
+	"encoding/json"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"
+	"io/ioutil"
 	"log"
 	"net"
-    "fmt"
-    "os"
-    "io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
 )
 
+// Button is a Dash, from Amazon
 type Button struct {
-    Name    string
-    Url     string
-    Mac     string
+	Name     string
+	URL      string
+	Username string
+	MAC      string
 }
+
+// Configuration is Network Interface and Buttons.
 type Configuration struct {
-    Buttons []Button
-    Nic     string
+	Buttons []Button
+	NIC     string
 }
 
 func loadConfig() Configuration {
-    file, _ := os.Open("conf.json")
-    decoder := json.NewDecoder(file)
-    configuration := Configuration{}
-    err := decoder.Decode(&configuration)
-    if err != nil {
-        fmt.Println("error:", err)
-    }
-    fmt.Println(configuration.Buttons)
-    return configuration
-}
-
-
-func makeRequest(url string) {
-	res, err := http.Post(url, "application/json", nil)
+	file, _ := os.Open("conf.json")
+	decoder := json.NewDecoder(file)
+	configuration := Configuration{}
+	err := decoder.Decode(&configuration)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln("Error Loading Configuration:", err)
 	}
-	body, err := ioutil.ReadAll(res.Body)
-	res.Body.Close()
-	if err != nil {
-		log.Fatal(err)
+	log.Println("Loaded", len(configuration.Buttons), "Button(s):")
+	for _, button := range configuration.Buttons {
+		log.Printf("- Button: %v (%v): %v\n", button.Name, button.MAC, button.URL)
 	}
-	fmt.Printf("%s\n", body)
+	return configuration
 }
-
 
 func main() {
+	var configuration = loadConfig()
+	log.Printf("Starting up on interface[%v]...", configuration.NIC)
 
-    var configuration = loadConfig()
+	var filter = "arp and ("
+	// Create a packet capture filter for the button's MAC addresses.
+	for _, button := range configuration.Buttons {
+		MAC, err := net.ParseMAC(button.MAC)
+		if err != nil {
+			log.Fatalf("Unable to parse MAC: %s (%s)\n", button.MAC, err)
+		}
+		if filter != "arp and (" {
+			filter += " or "
+		}
+		filter += "(ether src host " + MAC.String() + ")"
+	}
+	filter += ")"
+	capturePackates(configuration.NIC, filter, configuration.Buttons)
+}
 
-	log.Printf("Starting up on interface[%v]...", configuration.Nic)
-
-	h, err := pcap.OpenLive(configuration.Nic, 65536, true, pcap.BlockForever)
-
+func capturePackates(NIC string, filter string, buttons []Button) {
+	h, err := pcap.OpenLive(NIC, 65536, true, pcap.BlockForever)
+	defer h.Close()
 	if err != nil || h == nil {
 		log.Fatalf("Error opening interface: %s\nPerhaps you need to run as root?\n", err)
 	}
-	defer h.Close()
 
-    var filter = "arp and ("
-    for _,button := range configuration.Buttons {
-        mac, err := net.ParseMAC(button.Mac)
-        if err != nil {
-            log.Fatal(err)
-        }
-        filter += "(ether src host " + mac.String() + ")"
-    }
-    filter += ")"
-
-    err = h.SetBPFFilter(filter)
-	if err != nil {
-		log.Fatalf("Unable to set filter! %s\n", err)
+	if err = h.SetBPFFilter(filter); err != nil {
+		log.Fatalf("Unable to set filter: %s %s\n", filter, err)
 	}
-	log.Println("Listening for Dash buttons...")
 
+	log.Println("Listening for Dash buttons...")
 	packetSource := gopacket.NewPacketSource(h, h.LinkType())
 
-	// Since we're using a BPF filter to limit packets to only our buttons, we don't need to worry about anything besides MAC here...
+	// Using a BPF filter to limit packets to only our buttons,
+	// there is no need to capture anything besides MAC here.
 	for packet := range packetSource.Packets() {
 		ethernetLayer := packet.Layer(layers.LayerTypeEthernet)
 		ethernetPacket, _ := ethernetLayer.(*layers.Ethernet)
-         for _,button := range configuration.Buttons {
-            mac, err := net.ParseMAC(button.Mac)
-            if err != nil {
-                log.Fatal(err)
-            }
-		    if bytes.Equal(ethernetPacket.SrcMAC, mac) {
-                log.Printf("Button [%v] was pressed.", button.Name)
-                makeRequest(button.Url)
-            } else {
-			    log.Printf("Received button press, but don't know how to handle MAC[%v]", ethernetPacket.SrcMAC)
-            }
+		for _, button := range buttons {
+			if ethernetPacket.SrcMAC.String() == button.MAC {
+				log.Println("Button", button.Name, "was pressed.")
+				go makeRequest(button.URL, button.Username)
+				break
+			}
+			log.Printf("Received button press, but don't know how to handle MAC[%v]\n", ethernetPacket.SrcMAC)
 		}
 	}
+}
 
+func makeRequest(url string, username string) {
+	var cmd *exec.Cmd
+	if username != "" {
+		// Adding digest auth to Go looked like hell. This was a lot easier.
+		cmd = exec.Command("curl", "-u", username, "--digest", url)
+		cmd.Stderr = cmd.Stdout
+		output, err := cmd.Output()
+		if err != nil {
+			log.Println("Error Curling URL", url, "->", err)
+		} else {
+			log.Println("Curl Output:", string(output))
+		}
+	} else {
+		// TODO: don't hard code this to POST nor JSON. Put them in the config file.
+		res, err := http.Post(url, "application/json", nil)
+		if err != nil {
+			log.Println("Error POSTing to URL", url, "->", err)
+			return
+		}
+		defer func() {
+			// This is how you win the game of `errcheck`.
+			if err := res.Body.Close(); err != nil {
+				log.Println("Failed to close HTTP response body:", err)
+			}
+		}()
+		if output, err := ioutil.ReadAll(res.Body); err != nil {
+			log.Println("Error POSTing to URL", url, "->", err)
+		} else {
+			log.Println("POST Output:", string(output))
+		}
+	}
 }


### PR DESCRIPTION
I did a few things here:
1. Added the ability to use digest auth against an HTTP end-point. This uses curl because the `http` module does not have digest support and adding would double or triple the lines of code here. `curl` fits my needs.
2. Cleaned up the README a bit to reflect the new feature.
3. Updated the config file with a few more examples.
4. Fixed a bug that prevented multiple buttons from being used.
5. Fixed a bug in the button for loop that printed the message "don't know how to handle" after it handled it. Only happened with > 1 button.
6. Correct the variable names (`Nic`->`NIC`, `Url`->`URL`) to be more Go-like.
7. Added code comments for exported types. `Button` and `Configuration`.
8. Split `capturePackates()` out of `main()`.
9. Removed `.ParseMAC()` from the for loop. Replaced with `.String()`. Also removed `bytes` import.
10. Got rid of `fmt` and made everything go to `log` - we love time stamps.
11. Better error handling in `makeRequest()`

Probably best to look at `main.go` as a whole and not rely on the diff output because I moved a lot of things around.